### PR TITLE
fix breakage and test failures for v0 recipes

### DIFF
--- a/conda_forge_tick/migrators/version.py
+++ b/conda_forge_tick/migrators/version.py
@@ -223,8 +223,8 @@ class Version(Migrator):
     ) -> "MigrationUidTypedDict":
         version = attrs["new_version"]
         recipe_dir = Path(recipe_dir)
-        recipe_file = recipe_dir / "recipe" / "meta.yaml"
-        recipe_yaml = recipe_dir / "recipe" / "recipe.yaml"
+        recipe_file = recipe_dir / "meta.yaml"
+        recipe_yaml = recipe_dir / "recipe.yaml"
         if recipe_file.exists():
             raw_meta_yaml = recipe_file.read_text()
             updated_meta_yaml, errors = update_version(

--- a/tests/test_yaml/stdlib_rucio-clients_after_meta.yaml
+++ b/tests/test_yaml/stdlib_rucio-clients_after_meta.yaml
@@ -7,7 +7,7 @@ package:
   version: {{ version }}
 
 source:
-  url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/{{ name.replace('-', '_') }}-{{ version }}.tar.gz
+  url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/{{ name | replace('-', '_') }}-{{ version }}.tar.gz
   sha256: 92229d097012be2347266a633c655b46ca66ead0628becfa506ee6c4a9b38057
 
 build:

--- a/tests/test_yaml/stdlib_rucio-clients_before_meta.yaml
+++ b/tests/test_yaml/stdlib_rucio-clients_before_meta.yaml
@@ -7,7 +7,7 @@ package:
   version: {{ version }}
 
 source:
-  url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/{{ name.replace('-', '_') }}-{{ version }}.tar.gz
+  url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/{{ name | replace('-', '_') }}-{{ version }}.tar.gz
   sha256: c3fdaae0beb3ac10d82337d29cd5260c49bbb0f942d443bec6e997c51af74c0d
 
 build:

--- a/tests/test_yaml/version_21cmfast_correct.yaml
+++ b/tests/test_yaml/version_21cmfast_correct.yaml
@@ -6,7 +6,7 @@ package:
   version: {{ version }}
 
 source:
-  url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/{{ name.lower() }}-{{ version }}.tar.gz
+  url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/{{ name | lower }}-{{ version }}.tar.gz
   sha256: aff3b5a2adb30ad9a6c2274461901686606e9fdb5e3ff7040cbdf22755d7469f
 
 

--- a/tests/test_yaml/version_dash_extensions_correct.yaml
+++ b/tests/test_yaml/version_dash_extensions_correct.yaml
@@ -7,7 +7,7 @@ package:
   version: {{ version }}
 
 source:
-  url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/{{ name.replace('-', '_') }}-{{ version }}.tar.gz
+  url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/{{ name | replace('-', '_') }}-{{ version }}.tar.gz
   sha256: b36fcf6fd74d87cafdbabc9568c3ae0097712ccee8f7d59be8e916b51d40b106
 
 build:

--- a/tests/test_yaml/version_pypiurl_correct.yaml
+++ b/tests/test_yaml/version_pypiurl_correct.yaml
@@ -6,7 +6,7 @@ package:
   version: "{{ version }}"
 
 source:
-  url: "https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/{{ name.replace('_', '-') }}-{{ version }}.tar.gz"
+  url: "https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/{{ name | replace('_', '-') }}-{{ version }}.tar.gz"
   sha256: f3fe3f89011899b82451669cf1dbe4978523b8ac0f62c9c116429876fe8b6be8
 
 build:

--- a/tests/test_yaml/version_pyrsmq_correct.yaml
+++ b/tests/test_yaml/version_pyrsmq_correct.yaml
@@ -6,7 +6,7 @@ package:
   version: "{{ version }}"
 
 source:
-  url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/{{ name.lower() }}-{{ version }}.tar.gz
+  url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/{{ name | lower }}-{{ version }}.tar.gz
   sha256: dd1f8467e541935489be018dbb0ba1df8b903eb855bf1725947ceee41df92fa4
 
 build:

--- a/tests/test_yaml/version_quart_trio_correct.yaml
+++ b/tests/test_yaml/version_quart_trio_correct.yaml
@@ -6,7 +6,7 @@ package:
   version: {{ version }}
 
 source:
-  url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/{{ name.replace('-', '_').lower() }}-{{ version }}.tar.gz
+  url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/{{ name | replace('-', '_') | lower }}-{{ version }}.tar.gz
   sha256: 149c9c65c2faafdf455a4461b600e1983b71e593b6f8c8b91b592bbda36cea98
 
 build:

--- a/tests/test_yaml/version_riskfolio_lib_correct.yaml
+++ b/tests/test_yaml/version_riskfolio_lib_correct.yaml
@@ -6,7 +6,7 @@ package:
   version: {{ version }}
 
 source:
-  url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/{{ name.replace('-', '_').lower() }}-{{ version }}.tar.gz
+  url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/{{ name | replace('-', '_') | lower }}-{{ version }}.tar.gz
   sha256: 1048655b53a714ac045e756215275a302ae5c5816f3c73459b26056b054dbb46
   patches:
     - devendor-eigen-spectra.patch


### PR DESCRIPTION
All the migrations expect to get the `recipe` directory rather than the top feedstock directory, so update the logic back to expect that. Also update expected output for v0 tests. The v1 test still fails, need to figure out how to do all that properly.